### PR TITLE
Add Ansible setup playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Full Project
+
+This repository contains a FastAPI backend and a React frontend. A simple Ansible playbook is provided to install all required dependencies on a remote host.
+
+## Ansible usage
+
+1. Edit `ansible/inventory.ini` and replace `your_server_ip` and `your_user` with the remote host details.
+2. Update `project_root` in `ansible/install_dependencies.yml` if the project will be placed in a different directory on the remote host.
+3. Run the playbook:
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/install_dependencies.yml
+```
+
+The playbook installs system packages (Python, Node.js and build tools), then installs Python dependencies from `backend/requirements.txt` and Node dependencies for both the project root and the `frontend` directory.

--- a/ansible/install_dependencies.yml
+++ b/ansible/install_dependencies.yml
@@ -1,0 +1,34 @@
+---
+- name: Install dependencies for Full-project
+  hosts: full_project
+  become: true
+  vars:
+    project_root: /opt/full_project
+  tasks:
+    - name: Install system packages
+      apt:
+        update_cache: yes
+        name:
+          - python3
+          - python3-pip
+          - python3-venv
+          - build-essential
+          - libpq-dev
+          - nodejs
+          - npm
+        state: present
+
+    - name: Install backend Python dependencies
+      pip:
+        requirements: "{{ project_root }}/backend/requirements.txt"
+        virtualenv: "{{ project_root }}/venv"
+        virtualenv_python: python3
+
+    - name: Install root Node dependencies
+      npm:
+        path: "{{ project_root }}"
+
+    - name: Install frontend Node dependencies
+      npm:
+        path: "{{ project_root }}/frontend"
+

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,2 @@
+[full_project]
+remote_host ansible_host=your_server_ip ansible_user=your_user


### PR DESCRIPTION
## Summary
- add README with basic usage
- add inventory template
- add Ansible playbook to install Python/Node dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3bb62edc8322a9d1702f283f523f